### PR TITLE
Kubernetes descriptors

### DIFF
--- a/angular/deployment-svc.yml
+++ b/angular/deployment-svc.yml
@@ -1,0 +1,13 @@
+ apiVersion: v1
+ kind: Service
+ metadata:
+   labels:
+     app: devonfw-demo-angular
+   name: angular
+ spec:
+   ports:
+   - port: 80
+     targetPort: 80
+     protocol: TCP
+   selector:
+     app: devonfw-demo-angular

--- a/angular/deployment.yml
+++ b/angular/deployment.yml
@@ -3,20 +3,20 @@ kind: Deployment
 metadata:
   annotations:
   labels:
-    app: devonfw-demo-frontend
-  name: devonfw-demo-frontend
+    app: devonfw-demo-angular
+  name: devonfw-demo-angular
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: devonfw-demo-frontend
+      app: devonfw-demo-angular
   template:
     metadata:
       labels:
-        app: devonfw-demo-frontend
+        app: devonfw-demo-angular
     spec:
       containers:
-      - name: devonfw-demo-frontend
+      - name: devonfw-demo-angular
         image: INSERT_IMAGE_HERE
         imagePullPolicy: IfNotPresent
         readinessProbe:

--- a/angular/deployment.yml
+++ b/angular/deployment.yml
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+  labels:
+    app: devonfw-demo-frontend
+  name: devonfw-demo-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: devonfw-demo-frontend
+  template:
+    metadata:
+      labels:
+        app: devonfw-demo-frontend
+    spec:
+      containers:
+      - name: devonfw-demo-frontend
+        image: INSERT_IMAGE_HERE
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+            initialDelaySeconds: 120
+            httpGet:
+                path: /
+                port: 80

--- a/java/deployment-svc.yml
+++ b/java/deployment-svc.yml
@@ -1,0 +1,13 @@
+ apiVersion: v1
+ kind: Service
+ metadata:
+   labels:
+     app: devonfw-demo-java
+   name: java
+ spec:
+   ports:
+     - port: 8080
+       targetPort: 8080
+       protocol: TCP
+   selector:
+     app: devonfw-demo-java

--- a/java/deployment.yml
+++ b/java/deployment.yml
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+  labels:
+    app: devonfw-demo-java
+  name: devonfw-demo-java
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: devonfw-demo-java
+  template:
+    metadata:
+      labels:
+        app: devonfw-demo-java
+    spec:
+      containers:
+      - name: devonfw-demo-java
+        image: INSERT_IMAGE_HERE
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+            initialDelaySeconds: 120
+            httpGet:
+                path: /
+                port: 8080

--- a/reverse-proxy/deployment-svc.yml
+++ b/reverse-proxy/deployment-svc.yml
@@ -1,0 +1,13 @@
+ apiVersion: v1
+ kind: Service
+ metadata:
+   labels:
+     app: devonfw-demo-edge
+   name: edge
+ spec:
+   ports:
+   - port: 80
+     targetPort: 80
+     protocol: TCP
+   selector:
+     app: devonfw-demo-edge

--- a/reverse-proxy/deployment.yml
+++ b/reverse-proxy/deployment.yml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+  labels:
+    app: devonfw-demo-edge
+  name: devonfw-demo-edge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: devonfw-demo-edge
+  template:
+    metadata:
+      labels:
+        app: devonfw-demo-edge
+    spec:
+      containers:
+      - name: devonfw-demo-edge
+        image: INSERT_IMAGE_HERE
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+            httpGet:
+                path: /
+                port: 80


### PR DESCRIPTION
This changes are for kubernetes deployment of the java, angular and reverse-proxy

I would like also to propose the rename of "reverse-proxy" to something that is more meaningful like "edge-server" that is what I used to name inside the kubernetes deployment files

I've provided separated deployment.yml and deployment-svc.yml files 

On the deployment.yml file you need to replace the **INSERT_IMAGE_HERE** token with a valid docker image URL, that should go on your deploy to kubernetes scripts.

Maybe we can provide already built images on docker hub for OASP project so then we can put them there.

