### PR TITLE
Exception Handling for my-thai-star

### DIFF
--- a/java/mtsj/core/src/main/java/io/oasp/application/mtsj/ordermanagement/common/api/exception/OrderAlreadyExistException.java
+++ b/java/mtsj/core/src/main/java/io/oasp/application/mtsj/ordermanagement/common/api/exception/OrderAlreadyExistException.java
@@ -2,6 +2,8 @@ package io.oasp.application.mtsj.ordermanagement.common.api.exception;
 
 import net.sf.mmm.util.exception.api.NlsRuntimeException;
 
+import javax.validation.ValidationException;
+
 import io.oasp.application.mtsj.bookingmanagement.dataaccess.api.BookingEntity;
 import io.oasp.application.mtsj.ordermanagement.dataaccess.api.OrderEntity;
 
@@ -9,7 +11,7 @@ import io.oasp.application.mtsj.ordermanagement.dataaccess.api.OrderEntity;
  * This exception is thrown if a {@link BookingEntity} has already {@link OrderEntity} related.
  *
  */
-public class OrderAlreadyExistException extends NlsRuntimeException {
+public class OrderAlreadyExistException extends ValidationException {
 
   public OrderAlreadyExistException() {
     super("The order for this booking already exist. Please cancel the order before create a new one.");


### PR DESCRIPTION
This is with reference to #82. My-thai-star is currently throwing an error mentioning technology details etc. I had a look at RestServiceExceptionFacade class and as per my understanding we need to divide exceptions in this types: ValidationException, ValidationErrorUserException, securityExceptions, TechnicalErrorUserException.
If we extend from NlsRuntimeException it will throw TechnicalErrorUserException which shows all details. Here we need to decide in which category exception should be. As an example I have extended from ValidationException for creating OrderAlreadyExistException (as I think it can be categorized to validationException) and now I am getting correct message as below:

{
    "code": "ValidationError",
    "message": "The order for this booking already exist. Please cancel the order before create a new one.",
    "uuid": "9e847f4d-c073-496f-811a-819932415a8b"
}

I want to know which exception we should use for JWT exceptions such as JWTMalformException , UnsupportedJwtException etc. 
