### PR TITLE
Fixed Tracis CI status image in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = My Thai Star
 
-develop: image:https://travis-ci.org/oasp/my-thai-star.svg?branch=develop["build-status",link="https://travis-ci.org/oasp/my-thai-star"]
+develop: image:https://travis-ci.org/devonfw/my-thai-star.svg?branch=develop["build-status",link="https://travis-ci.org/devonfw/my-thai-star"]
 
 
 This repository is an **iCSD Capgemini** initiative that hosts an application reference called **My Thai Star**. This application is about the management of a restaurant.


### PR DESCRIPTION
The Travis CI status image was pointing to the old OASP repository. 