### PR TITLE
fix MTSJ server pom spring-boot-maven-plugin

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -7,7 +7,7 @@ RUN mvn clean install
 # 2. Deploy Java war
 FROM java:8
 WORKDIR /app
-COPY --from=build /app/server/target/mtsj-server-bootified.war /app/
+COPY --from=build /app/server/target/mythaistar-bootified.war /app/
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 CMD curl --fail http://localhost:8081/mythaistar/services/rest/dishmanagement/v1/category/0/ || exit 1 
-ENTRYPOINT ["java","-jar","/app/mtsj-server-bootified.war"]
+ENTRYPOINT ["java","-jar","/app/mythaistar-bootified.war"]
 EXPOSE 8081

--- a/java/mtsj/server/pom.xml
+++ b/java/mtsj/server/pom.xml
@@ -138,7 +138,6 @@
         <configuration>
           <mainClass>com.devonfw.application.mtsj.SpringBootApp</mainClass>
           <classifier>bootified</classifier>
-          <finalName>${project.artifactId}</finalName>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Reading the actual pom located on /java/mtsj/server two artifacts should be created: mythaistar.war. and mtsj-server-bootified.war.

The problem seems that the plugin in Linux doesn't read the property _\<finalName>${project.artifactId}\</finalName>_ and is taking the name of his father _\<finalName>${server.war.name}\</finalName>_ then the artifacts create at the end are mythaistar.war and mythaistar-bootified.war.

To solve it, as what is missing is the child's variable to create the bootified, I propose to eliminate it and then is going to be named just like his father and the final name is going to be mythaistar-bootified.war in all environments/technologies.

More information [here](https://github.com/devonfw/my-thai-star/issues/212).