### PR TITLE
Refactor statements with var and for keywords

### DIFF
--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -1,15 +1,14 @@
 import { Component } from '@angular/core';
-import { Route, Router, RouterOutlet } from '@angular/router';
-import { SidenavService } from './sidenav/shared/sidenav.service';
-import { AuthService } from './core/authentication/auth.service';
-import { ElectronService } from './shared/electron/electron.service';
+import { Router, RouterOutlet } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { find } from 'lodash';
-import { fadeAnimation } from './animations/fade.animation';
 import * as moment from 'moment';
-import { ConfigService } from './core/config/config.service';
+import { fadeAnimation } from './animations/fade.animation';
 import { PredictionCockpitComponent } from './cockpit-area/prediction-cockpit/prediction-cockpit.component';
-import { AuthGuardService } from './core/authentication/auth-guard.service';
+import { AuthService } from './core/authentication/auth.service';
+import { ConfigService } from './core/config/config.service';
+import { ElectronService } from './shared/electron/electron.service';
+import { SidenavService } from './sidenav/shared/sidenav.service';
 
 @Component({
   selector: 'public-main',
@@ -44,25 +43,24 @@ export class AppComponent {
       translate.use(translate.getBrowserLang());
     }
     moment.locale(this.translate.currentLang);
-  
+
     if (configService.getValues().enablePrediction) {
-	  // change prediction route component from NotSupportedComponent to PredictionCockpitComponent
-      var currentRoutes = router.config;
-      var newRoutes = [];
-      for (var i = 0 ; i < currentRoutes.length ; i++) {
-        if (currentRoutes[i].path == "prediction") {
-          newRoutes.push(
+      // change prediction route component from NotSupportedComponent to PredictionCockpitComponent
+      const currentRoutes = router.config;
+      const newRoutes = currentRoutes.reduce((accum, current) => {
+        if (current.path === 'prediction') {
+          accum.push(
             {
-              path: currentRoutes[i].path,
+              path: current.path,
               component: PredictionCockpitComponent,
-              canActivate: currentRoutes[i].canActivate,
+              canActivate: current.canActivate,
             }
           );
+        } else {
+          accum.push(current);
         }
-        else {
-          newRoutes.push(currentRoutes[i]);
-        }
-      }
+        return accum;
+      }, []);
       router.resetConfig(newRoutes);
     }
 

--- a/angular/src/app/cockpit-area/cockpit.module.ts
+++ b/angular/src/app/cockpit-area/cockpit.module.ts
@@ -22,7 +22,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
     HttpClientModule,
     TranslateModule,
     CoreModule,
-	  FormsModule,
+    FormsModule,
     ReactiveFormsModule,
   ],
   providers: [

--- a/angular/src/app/cockpit-area/prediction-cockpit/prediction-cockpit.component.spec.ts
+++ b/angular/src/app/cockpit-area/prediction-cockpit/prediction-cockpit.component.spec.ts
@@ -1,20 +1,22 @@
-import { HttpClient/*, HttpClientModule*/ } from '@angular/common/http';
-import { PredictionCockpitComponent } from './prediction-cockpit.component';
-import { PredictionService } from '../shared/prediction.service';
-import { PriceCalculatorService } from '../../sidenav/shared/price-calculator.service';
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ConfigService } from '../../core/config/config.service';
-import { MatDialog } from '@angular/material';
-import { TranslateService } from '@ngx-translate/core';
+import { PredictionService } from '../shared/prediction.service';
+import { PredictionCockpitComponent } from './prediction-cockpit.component';
+import { TestBed } from '@angular/core/testing';
 
 describe('PredictionCockpitComponent', () => {
   let component: PredictionCockpitComponent;
   let http: HttpClient;
   let configService: ConfigService;
   let predictionService: PredictionService;
-  let translate: TranslateService;
-  let dialog: MatDialog;
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    http = TestBed.get(HttpClient);
+
     configService = new ConfigService(http);
     predictionService = new PredictionService(
       http,

--- a/angular/src/app/cockpit-area/prediction-cockpit/prediction-cockpit.component.ts
+++ b/angular/src/app/cockpit-area/prediction-cockpit/prediction-cockpit.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { FilterOrdersCockpit, PredictionCriteria } from 'app/shared/backend-models/interfaces';
+import { FilterOrdersCockpit, PredictionCriteria } from '../../shared/backend-models/interfaces';
 import { Chart } from 'chart.js';
 import { Moment } from 'moment';
 import { OwlDateTimeComponent } from 'ng-pick-datetime';

--- a/angular/src/app/cockpit-area/prediction-cockpit/prediction-cockpit.component.ts
+++ b/angular/src/app/cockpit-area/prediction-cockpit/prediction-cockpit.component.ts
@@ -1,14 +1,10 @@
-import { PredictionService } from '../shared/prediction.service';
-import { OrdersData } from '../../shared/view-models/interfaces';
-import { Observable } from 'rxjs/Observable';
-import { Chart } from 'chart.js';
-import { Component, ViewChild, ElementRef, OnInit } from '@angular/core';
-import { config } from '../../config';
-import { ITdDataTableColumn } from '@covalent/core';
-import { PredictionCriteria, FilterOrdersCockpit } from 'app/shared/backend-models/interfaces';
-import { OwlDateTimeComponent } from 'ng-pick-datetime';
-import { Moment } from 'moment';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
+import { FilterOrdersCockpit, PredictionCriteria } from 'app/shared/backend-models/interfaces';
+import { Chart } from 'chart.js';
+import { Moment } from 'moment';
+import { OwlDateTimeComponent } from 'ng-pick-datetime';
+import { PredictionService } from '../shared/prediction.service';
 
 @Component({
   selector: 'cockpit-prediction-cockpit',
@@ -35,24 +31,30 @@ export class PredictionCockpitComponent implements OnInit {
       pageNumber: 0
     },
     type: 'prediction',
-    startBookingdate: new Date(this.currentStartDate.value.getFullYear(), this.currentStartDate.value.getMonth(), this.currentStartDate.value.getDate()).toISOString(),
+    startBookingdate: new Date(this.currentStartDate.value.getFullYear(),
+      this.currentStartDate.value.getMonth(),
+      this.currentStartDate.value.getDate()).toISOString(),
     temperatures: [22.2, 24.8, 26.7, 22, 23.1, 23, 20.8],
     holidays: Array(7).fill(null).map((x, i) => i !== 4 ? x : 'Holiday!')
   };
   dailyFilter: FilterOrdersCockpit = {
-	pageable : {
+  pageable : {
       pageSize : 10000,
       pageNumber : 0
-	},
+  },
     type: 'daily',
-    startBookingdate: new Date(this.currentStartDate.value.getFullYear(), this.currentStartDate.value.getMonth(), this.currentStartDate.value.getDate() - 7).toISOString(),
-    endBookingdate: new Date(this.currentEndDate.value.getFullYear(), this.currentEndDate.value.getMonth(), this.currentEndDate.value.getDate() - 1).toISOString()
+    startBookingdate: new Date(this.currentStartDate.value.getFullYear(),
+      this.currentStartDate.value.getMonth(),
+      this.currentStartDate.value.getDate() - 7).toISOString(),
+    endBookingdate: new Date(this.currentEndDate.value.getFullYear(),
+      this.currentEndDate.value.getMonth(),
+      this.currentEndDate.value.getDate() - 1).toISOString()
   };
   monthlyFilter: FilterOrdersCockpit = {
-	pageable : {
+  pageable : {
       pageSize : 10000,
       pageNumber : 0
-	},
+  },
     type: 'monthly',
     startBookingdate: new Date(this.currentStartDate.value.getFullYear(), this.currentStartDate.value.getMonth() - 12, 1).toISOString(),
     endBookingdate: new Date().toISOString()
@@ -73,17 +75,17 @@ export class PredictionCockpitComponent implements OnInit {
   }
 
   colorGenerator(size: number): { r: number, g: number, b: number }[] {
-    let hs = Array(size).fill(0).map((_, i) => i / size);
-    let s = .5;
-    let v = .9;
-    let p = v * (1 - s);
+    const hs = Array(size).fill(0).map((_, i) => i / size);
+    const s = .5;
+    const v = .9;
+    const p = v * (1 - s);
 
     return hs.map(h => {
       let r, g, b;
-      let i = Math.floor(h * 6);
-      let f = h * 6 - i;
-      let q = v * (1 - f * s);
-      let t = v * (1 - (1 - f) * s);
+      const i = Math.floor(h * 6);
+      const f = h * 6 - i;
+      const q = v * (1 - f * s);
+      const t = v * (1 - (1 - f) * s);
 
       switch (i % 6) {
         case 0: r = v, g = t, b = p; break;
@@ -104,14 +106,14 @@ export class PredictionCockpitComponent implements OnInit {
 
   updateGraphClick(evt: any) {
     return this.fetchOrders(
-      evt.currentTarget.dataset.type === "daily"
+      evt.currentTarget.dataset.type === 'daily'
         ? this.dailyFilter
         : this.monthlyFilter
     );
   }
 
   fetchOrders(filter: FilterOrdersCockpit | PredictionCriteria) {
-    let data = [];
+    const data = [];
     let labels = [];
 
     if (filter.type === 'prediction') {
@@ -122,8 +124,8 @@ export class PredictionCockpitComponent implements OnInit {
       this.monthlyBusy = true;
     }
 
-    let json = JSON.stringify(filter);
-    let observable = filter.type === 'prediction'
+    const json = JSON.stringify(filter);
+    const observable = filter.type === 'prediction'
       ? this.predictionService.getPrediction(filter as PredictionCriteria)
       : this.predictionService.getOrders(filter as FilterOrdersCockpit);
 
@@ -142,10 +144,10 @@ export class PredictionCockpitComponent implements OnInit {
         });
       });
 
-      //we need color generator for number of dishes we have,
-      let colors = this.colorGenerator(orders.dishes.length);
+      // we need color generator for number of dishes we have,
+      const colors = this.colorGenerator(orders.dishes.length);
       data.forEach((record, index) => {
-        let color = colors[index]
+        const color = colors[index];
         record.backgroundColor = 'rgba(' + color.r + ',' + color.g + ',' + color.b + ',0.2)';
         record.backgroundColor = 'rgba(' + color.r + ',' + color.g + ',' + color.b + ',0.2)';
         record.borderColor = 'rgba(' + color.r + ',' + color.g + ',' + color.b + ',1)';
@@ -158,14 +160,14 @@ export class PredictionCockpitComponent implements OnInit {
       switch (filter.type) {
         case 'monthly':
           labels = orders.dates.map((date, index) => {
-            return [date.toLocaleDateString('en-GB', { month: "short" })];
+            return [date.toLocaleDateString('en-GB', { month: 'short' })];
           });
           break;
         case 'daily':
         case 'prediction':
           labels = orders.dates.map((date, index) => {
             return [
-              date.toLocaleDateString('en-GB', { weekday: "short" }) + ' ' + date.toLocaleDateString('en-GB'),
+              date.toLocaleDateString('en-GB', { weekday: 'short' }) + ' ' + date.toLocaleDateString('en-GB'),
               orders.weather[index] + '°C'
             ];
           });
@@ -173,9 +175,9 @@ export class PredictionCockpitComponent implements OnInit {
       }
 
       if (filter.type === 'daily' || filter.type === 'prediction') {
-        //get the max value of all orders to set it as value of holiday bar
-        let max = Math.ceil(Math.max(...data.map(record => Math.max(...record.data))) / 10) * 10;
-        let weekHolidays = orders.holidays.map((record, index) => {
+        // get the max value of all orders to set it as value of holiday bar
+        const max = Math.ceil(Math.max(...data.map(record => Math.max(...record.data))) / 10) * 10;
+        const weekHolidays = orders.holidays.map((record, index) => {
           return record ? max : 0;
         });
         data.push({
@@ -210,7 +212,7 @@ export class PredictionCockpitComponent implements OnInit {
         });
         chartCanvas.update();
       } else {
-        let config = chartCanvas = {
+        const config = chartCanvas = {
           type: 'bar',
           data: {
             labels: labels,
@@ -225,7 +227,7 @@ export class PredictionCockpitComponent implements OnInit {
               display: true,
               labels: {
                 filter: (dataLabel, chart) => {
-                  if (dataLabel.text !== "holiday") {
+                  if (dataLabel.text !== 'holiday') {
                     return dataLabel;
                   }
                 },
@@ -233,17 +235,17 @@ export class PredictionCockpitComponent implements OnInit {
             },
             tooltips: {
               callbacks: {
-                label: (tooltipItem, data) => {
-                  let orders = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
-                  let ordersLabel = Math.round(orders * 10) / 10 + ' order' + (orders !== 1 ? 's' : '');
+                label: (tooltipItem, dataTooltip) => {
+                  const ordersTooltip = dataTooltip.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
+                  const ordersLabel = Math.round(ordersTooltip * 10) / 10 + ' order' + (ordersTooltip !== 1 ? 's' : '');
 
                   switch (filter.type) {
                     case 'monthly':
                       return ordersLabel;
                     case 'daily':
                     case 'prediction':
-                      if (data.datasets[tooltipItem.datasetIndex].designation) {
-                        return data.datasets[tooltipItem.datasetIndex].designation[tooltipItem.index];
+                      if (dataTooltip.datasets[tooltipItem.datasetIndex].designation) {
+                        return dataTooltip.datasets[tooltipItem.datasetIndex].designation[tooltipItem.index];
                       }
 
                       return ordersLabel;
@@ -252,7 +254,7 @@ export class PredictionCockpitComponent implements OnInit {
               }
             },
           }
-        }
+        };
         switch (filter.type) {
           case 'monthly':
             ctx = this.monthlyChart.nativeElement.getContext('2d');
@@ -288,45 +290,49 @@ export class PredictionCockpitComponent implements OnInit {
   }
 
   getEditPredictionDayLabel() {
-    let date = new Date(this.currentStartDate.value.getFullYear(), this.currentStartDate.value.getMonth(), this.currentStartDate.value.getDate() + this.editPredictionDayIndex);
+    const date = new Date(this.currentStartDate.value.getFullYear(),
+      this.currentStartDate.value.getMonth(),
+      this.currentStartDate.value.getDate() + this.editPredictionDayIndex);
 
-    return date.toLocaleDateString('en-GB', { weekday: "short" }) + ' ' + date.toLocaleDateString('en-GB');
+    return date.toLocaleDateString('en-GB', { weekday: 'short' }) + ' ' + date.toLocaleDateString('en-GB');
   }
-  
+
   monthlyCalendarYearHandler( calendarDate: Moment, filterType: String ) {
-    if (filterType === "start") {
-      var dateValue = this.currentStartDate.value;
+    if (filterType === 'start') {
+      const dateValue = this.currentStartDate.value;
       dateValue.setFullYear(calendarDate.year());
       dateValue.setDate(1);
       this.currentStartDate.setValue(dateValue);
-      this.monthlyFilter.startBookingdate = new Date(this.currentStartDate.value.getFullYear(), this.currentStartDate.value.getMonth(), 1).toISOString();
-    }
-    else if (filterType === "end") {
-      var dateValue = this.currentEndDate.value;
+      this.monthlyFilter.startBookingdate = new Date(this.currentStartDate.value.getFullYear(),
+        this.currentStartDate.value.getMonth(), 1).toISOString();
+    } else if (filterType === 'end') {
+      const dateValue = this.currentEndDate.value;
       dateValue.setFullYear(calendarDate.year());
       dateValue.setDate(1);
       this.currentEndDate.setValue(dateValue);
-      this.monthlyFilter.endBookingdate = new Date(this.currentEndDate.value.getFullYear(), this.currentEndDate.value.getMonth(), 1).toISOString();
+      this.monthlyFilter.endBookingdate = new Date(this.currentEndDate.value.getFullYear(),
+        this.currentEndDate.value.getMonth(), 1).toISOString();
     }
   }
 
   monthlyCalendarMonthHandler( calendarDate: Moment, filterType: String, datepicker: OwlDateTimeComponent<Moment> ) {
 
-    if (filterType === "start") {
-      var dateValue = this.currentStartDate.value;
+    if (filterType === 'start') {
+      const dateValue = this.currentStartDate.value;
       dateValue.setFullYear(calendarDate.year());
       dateValue.setMonth(calendarDate.month());
       dateValue.setDate(1);
       this.currentStartDate.setValue(dateValue);
-      this.monthlyFilter.startBookingdate = new Date(this.currentStartDate.value.getFullYear(), this.currentStartDate.value.getMonth(), 1).toISOString();
-    }
-    else if (filterType === "end") {
-      var dateValue = this.currentEndDate.value;
+      this.monthlyFilter.startBookingdate = new Date(this.currentStartDate.value.getFullYear(),
+        this.currentStartDate.value.getMonth(), 1).toISOString();
+    } else if (filterType === 'end') {
+      const dateValue = this.currentEndDate.value;
       dateValue.setFullYear(calendarDate.year());
       dateValue.setMonth(calendarDate.month());
       dateValue.setDate(1);
       this.currentEndDate.setValue(dateValue);
-      this.monthlyFilter.endBookingdate = new Date(this.currentEndDate.value.getFullYear(), this.currentEndDate.value.getMonth(), 1).toISOString();
+      this.monthlyFilter.endBookingdate = new Date(this.currentEndDate.value.getFullYear(),
+        this.currentEndDate.value.getMonth(), 1).toISOString();
     }
     datepicker.close();
   }

--- a/angular/src/app/config.ts
+++ b/angular/src/app/config.ts
@@ -4,7 +4,7 @@ export const config: any = {
   roles: [
     { name: 'CUSTOMER', permission: 0 },
     { name: 'WAITER', permission: 1 },
-	{ name: 'MANAGER', permission: 2 },
+    { name: 'MANAGER', permission: 2 },
   ],
   langs: [
     { label: 'English', value: 'en' },

--- a/angular/src/app/core/authentication/auth-guard.service.ts
+++ b/angular/src/app/core/authentication/auth-guard.service.ts
@@ -26,7 +26,9 @@ export class AuthGuardService implements CanActivate {
       return true;
     }
 
-    if ((state.url === '/orders' || state.url === '/reservations') && this.authService.isLogged() && this.authService.isPermited('WAITER')) {
+    if ((state.url === '/orders' || state.url === '/reservations')
+      && this.authService.isLogged()
+      && this.authService.isPermited('WAITER')) {
       return true;
     }
 

--- a/angular/src/app/core/config/config.service.ts
+++ b/angular/src/app/core/config/config.service.ts
@@ -28,7 +28,7 @@ export class ConfigService {
         });
         return settings;
       })
-      .catch((error) => {
+      .catch(() => {
         return 'ok, no external configuration';
       });
 

--- a/angular/src/app/core/config/config.ts
+++ b/angular/src/app/core/config/config.ts
@@ -38,7 +38,7 @@ export const config: Config = {
   roles: [
     { name: 'CUSTOMER', permission: 0 },
     { name: 'WAITER', permission: 1 },
-	{ name: 'MANAGER', permission: 2 },
+    { name: 'MANAGER', permission: 2 },
   ],
   langs: [
     { label: 'English', value: 'en' },

--- a/angular/src/app/email-confirmations/email-confirmations.component.ts
+++ b/angular/src/app/email-confirmations/email-confirmations.component.ts
@@ -28,9 +28,9 @@ export class EmailConfirmationsComponent implements OnInit {
     let errorUrlString: string;
     let emailConfirmationStrings: any;
     forkJoin(
-      this.translate.get('alerts.genericError'),
+      [this.translate.get('alerts.genericError'),
       this.translate.get('alerts.urlError'),
-      this.translate.get('alerts.email confirmations'),
+      this.translate.get('alerts.email confirmations')],
     ).subscribe((translation: any) => {
       errorString = translation[0];
       errorUrlString = translation[1];

--- a/angular/src/app/email-confirmations/email-confirmations.component.ts
+++ b/angular/src/app/email-confirmations/email-confirmations.component.ts
@@ -27,11 +27,11 @@ export class EmailConfirmationsComponent implements OnInit {
     let errorString: string;
     let errorUrlString: string;
     let emailConfirmationStrings: any;
-    forkJoin(
-      [this.translate.get('alerts.genericError'),
+    forkJoin([
+      this.translate.get('alerts.genericError'),
       this.translate.get('alerts.urlError'),
-      this.translate.get('alerts.email confirmations')],
-    ).subscribe((translation: any) => {
+      this.translate.get('alerts.email confirmations'),
+    ]).subscribe((translation: any) => {
       errorString = translation[0];
       errorUrlString = translation[1];
       emailConfirmationStrings = translation[2];

--- a/angular/src/app/shared/backend-models/interfaces.ts
+++ b/angular/src/app/shared/backend-models/interfaces.ts
@@ -83,7 +83,7 @@ export class OrderListInfo {
 }
 
 export class PredictionCriteria {
-	pageable?: Pageable;
+    pageable?: Pageable;
     type: string;
     startBookingdate: string;
     temperatures: number[];

--- a/angular/src/app/shared/view-models/interfaces.ts
+++ b/angular/src/app/shared/view-models/interfaces.ts
@@ -105,7 +105,7 @@ export interface OrderResponse {
   content: OrderListView;
 }
 
-//Interface to recieve responeses from the server using httpclient for get OrderDishResponse
+// Interface to recieve responeses from the server using httpclient for get OrderDishResponse
 export interface OrderDishResponse {
     pageable: Pageable;
     result: OrderDishListView;
@@ -153,17 +153,17 @@ export interface Role {
 
 // Interface for prediction data for a dish
 export interface OrdersData {
-    dates?: Date[],
-    holidays?: string[],
-    weather?: number[],
-    dishes: DishOrdersData[]
+    dates?: Date[];
+    holidays?: string[];
+    weather?: number[];
+    dishes: DishOrdersData[];
 }
 
-//Interface for order of a dish
+// Interface for order of a dish
 export interface DishOrdersData {
-    id: number,
-    //name of the dish
-    name: string,
-    //count of orders of the dish, that have been ordered in certain period
-    orders: number[],
+    id: number;
+    // name of the dish
+    name: string;
+    // count of orders of the dish, that have been ordered in certain period
+    orders: number[];
 }

--- a/angular/src/app/user-area/shared/user-area.service.ts
+++ b/angular/src/app/user-area/shared/user-area.service.ts
@@ -48,12 +48,13 @@ export class UserAreaService {
               this.authService.setLogged(true);
               this.authService.setUser(loginInfo.name);
               this.authService.setRole(loginInfo.role);
-              if (loginInfo.role==="CUSTOMER") 
+              if (loginInfo.role === 'CUSTOMER') {
                 this.router.navigate(['restaurant']);
-              else if (loginInfo.role==="WAITER")
+              } else if (loginInfo.role === 'WAITER') {
                 this.router.navigate(['orders']);
-              else if (loginInfo.role==="MANAGER")
+              } else if (loginInfo.role === 'MANAGER') {
                 this.router.navigate(['prediction']);
+              }
               this.snackBar.openSnack(
                 this.authAlerts.loginSuccess,
                 4000,
@@ -83,7 +84,7 @@ export class UserAreaService {
             'green',
           );
         },
-        (error: any) => {
+        () => {
           this.snackBar.openSnack(this.authAlerts.registerFail, 4000, 'red');
         },
       );


### PR DESCRIPTION
The main intention of this PR is to refactor two parts of code concretely from [app.component.ts](https://github.com/devonfw/my-thai-star/pull/215/files#diff-129ecab9d370e6a798ec66de1debeb1fL50) and [prediction.service.ts](https://github.com/devonfw/my-thai-star/pull/215/files#diff-e74789857b70958131d7008970f7353eL91), that were using the `var` keyword for declaring variables and the `for` keyword to loop over arrays. 
The `var` keyword is considered a bad practice and as we are using [Typescript](https://www.typescriptlang.org/docs/handbook/variable-declarations.html) we can use the `let` or `const` keywords, while a `for` can be easily replaced by the native ES5+ operations like `map`, `forEach`, `reduce`, etc, that are prefered. 
This is really critical since the my-thai-star project is intended to be used as a reference, and could be misunderstood by new users, so we must avoid doing this.

The rest of the PR fixes the errors that the `npm run lint` command was outputting. 