### PR TITLE
Fixed store management, components and services

### DIFF
--- a/angular/src/app/menu/components/menu-card/menu-card-details/menu-card-details.component.html
+++ b/angular/src/app/menu/components/menu-card/menu-card-details/menu-card-details.component.html
@@ -14,8 +14,8 @@
 <div class="extras">
   <mat-checkbox
     *ngFor="let extra of menuInfo.extras"
-    [checked]="extra.selected"
-    (change)="onSelectExtra(extra)"
+    [ngModel]="extra.selected"
+    (change)="onToggleExtra(extra, $event)"
   >
     {{ extra.name }} +{{ extra.price }}€
   </mat-checkbox>

--- a/angular/src/app/menu/components/menu-card/menu-card-details/menu-card-details.component.ts
+++ b/angular/src/app/menu/components/menu-card/menu-card-details/menu-card-details.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { DishView, ExtraView } from 'app/shared/view-models/interfaces';
+import { MatCheckboxChange } from '@angular/material';
 
 @Component({
   selector: 'own-menu-card-details',
@@ -13,13 +14,13 @@ export class MenuCardDetailsComponent {
     ExtraView
   >();
 
-  onSelectExtra(extra: ExtraView): void {
-    const modifiedExtraIndex: number = this.menuInfo.extras.indexOf(extra);
-    const oldExtra: ExtraView = this.menuInfo.extras[modifiedExtraIndex];
-    this.menuInfo.extras[modifiedExtraIndex] = {
-      ...oldExtra,
-      ...{ selected: !oldExtra.selected },
-    };
+  onToggleExtra(extra: ExtraView, event: MatCheckboxChange): void {
+    const modifiedExtra = this.menuInfo.extras.find((e) => e.id === extra.id);
+    const item = Object.assign({
+      ...modifiedExtra,
+      selected: event.checked,
+    });
+    this.selectExtra.emit(item);
   }
 
   onClickOrder(): void {

--- a/angular/src/app/menu/components/menu-card/menu-card.component.html
+++ b/angular/src/app/menu/components/menu-card/menu-card.component.html
@@ -1,11 +1,18 @@
 <mat-card class="details-card">
-  <div class= "menu-image" [style.background-image]="'url(' + menuInfo.image.content + ')'">
-    <button mat-fab
-            *ngIf="auth"
-            (click)="changeFavouriteState()"
-            class="favourite-button"
+  <div
+    class="menu-image"
+    [style.background-image]="'url(' + menuInfo.image.content + ')'"
+  >
+    <button
+      mat-fab
+      *ngIf="auth"
+      (click)="changeFavouriteState()"
+      class="favourite-button"
     >
-      <mat-icon [class.fab-on]="!menuInfo.isfav" [class.fab-off]="menuInfo.isfav">
+      <mat-icon
+        [class.fab-on]="!menuInfo.isfav"
+        [class.fab-off]="menuInfo.isfav"
+      >
         star
       </mat-icon>
     </button>
@@ -13,7 +20,9 @@
     <own-menu-card-comments class="reviews"></own-menu-card-comments>
   </div>
 
-  <own-menu-card-details [menuInfo]="menuInfo"
-                         (clickOrder)="addOrderMenu()"
+  <own-menu-card-details
+    [menuInfo]="menuInfo"
+    (selectExtra)="selectedOption($event)"
+    (clickOrder)="addOrderMenu()"
   ></own-menu-card-details>
 </mat-card>

--- a/angular/src/app/menu/components/menu-card/menu-card.component.ts
+++ b/angular/src/app/menu/components/menu-card/menu-card.component.ts
@@ -1,5 +1,5 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
-import { DishView, ExtraView } from 'app/shared/view-models/interfaces';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { DishView, ExtraView } from '../../../shared/view-models/interfaces';
 
 @Component({
   selector: 'public-menu-card',
@@ -13,27 +13,18 @@ export class MenuCardComponent {
   @Output() orderAdded = new EventEmitter<any>();
   @Output() extraSelected = new EventEmitter<any>();
 
-  constructor(
-  ) {}
+  constructor() {}
 
-  changeFavouriteState(): void {
+  changeFavouriteState() {
     this.menuInfo.isfav = !this.menuInfo.isfav;
   }
 
-  selectedOption(extra: ExtraView): void {
-    extra.selected = !extra.selected;
+  selectedOption(extra: ExtraView) {
+    const dish = this.menuInfo;
+    this.extraSelected.emit({ dish, extra });
   }
 
-  addOrderMenu(): void {
+  addOrderMenu() {
     this.orderAdded.emit(this.menuInfo);
-  }
-
-  receiveExtra($event) {
-    this.extras = $event;
-    this.extraSelected.emit(this.extras);
-  }
-
-  addSelectExtra(): void {
-    this.extraSelected.emit(this.extras);
   }
 }

--- a/angular/src/app/menu/services/menu.service.ts
+++ b/angular/src/app/menu/services/menu.service.ts
@@ -7,6 +7,7 @@ import { ConfigService } from '../../core/config/config.service';
 import { DishView, ExtraView } from '../../shared/view-models/interfaces';
 import { FilterFormData } from '../components/menu-filters/menu-filters.component';
 import { Order } from '../models/order.model';
+import * as fromMenu from '../store';
 
 const categoryNameToServerId: { [key: string]: number } = Object.freeze({
   mainDishes: 0,
@@ -62,12 +63,6 @@ export class MenuService {
       minLikes: filters.minLikes,
       isFav: undefined, // TODO: what is this field? It was present in interface but setting it will cause errors ...
     };
-  }
-
-  clearSelectedExtras(menuInfo: DishView): void {
-    menuInfo.extras.map((extra: ExtraView) => {
-      extra.selected = false;
-    });
   }
 
   getDishes(

--- a/angular/src/app/menu/store/actions/menu.actions.ts
+++ b/angular/src/app/menu/store/actions/menu.actions.ts
@@ -1,4 +1,4 @@
-import { props, createAction, union } from '@ngrx/store';
+import { createAction, props, union } from '@ngrx/store';
 import { Filter, Pageable } from '../../../shared/backend-models/interfaces';
 import { DishView } from '../../../shared/view-models/interfaces';
 
@@ -12,15 +12,21 @@ export const loadMenusSuccess = createAction(
   props<{ pageable?: Pageable; content?: DishView[] }>(),
 );
 
-export const loadMenuFail = createAction(
+export const loadMenusFail = createAction(
   '[Menu] Load Menus Fail',
   props<{ error: Error }>(),
+);
+
+export const updateDishExtras = createAction(
+  '[Menu] Select Dish Extras',
+  props<{ dish: DishView }>(),
 );
 
 // action types
 const all = union({
   loadMenus,
   loadMenusSuccess,
-  loadMenuFail,
+  loadMenusFail,
+  updateDishExtras,
 });
 export type MenuActions = typeof all;

--- a/angular/src/app/menu/store/effects/menu.effects.ts
+++ b/angular/src/app/menu/store/effects/menu.effects.ts
@@ -1,23 +1,36 @@
 import { Injectable } from '@angular/core';
-import { Actions, ofType, createEffect } from '@ngrx/effects';
-import {catchError, map, mergeMap} from 'rxjs/operators';
-import {of} from 'rxjs';
-import * as loadMenusActions from '../actions/menu.actions';
-import {MenuService} from '../../services/menu.service';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { of } from 'rxjs';
+import { catchError, map, mergeMap } from 'rxjs/operators';
+import { MenuService } from '../../services/menu.service';
+import * as loadMenusActions from '../actions';
 
 @Injectable()
 export class MenuEffects {
-  loadDishes$ = createEffect(() => this.actions$.pipe(
-    ofType(loadMenusActions.loadMenus),
-    map(action => action.filter),
-    mergeMap(filter => this.menuService.getDishes(filter).pipe(
-      map(result => loadMenusActions.loadMenusSuccess(result)),
-      catchError(error => of(loadMenusActions.loadMenuFail({error: error})))
-    ))
-  ));
+  loadDishes$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(loadMenusActions.loadMenus),
+      map((action) => action.filter),
+      mergeMap((filter) =>
+        this.menuService.getDishes(filter).pipe(
+          map((result) => {
+            const content = result.content.map((d) => {
+              d.extras.map((e) => {
+                e.selected = false;
+                return e;
+              });
+              return d;
+            });
+            const resultAdapted = { pageable: result.pageable, content };
+            return loadMenusActions.loadMenusSuccess(resultAdapted);
+          }),
+          catchError((error) =>
+            of(loadMenusActions.loadMenusFail({ error: error })),
+          ),
+        ),
+      ),
+    ),
+  );
 
-  constructor (
-    private actions$: Actions,
-    private menuService: MenuService
-  ) {}
+  constructor(private actions$: Actions, private menuService: MenuService) {}
 }

--- a/angular/src/app/menu/store/reducers/menu.reducer.ts
+++ b/angular/src/app/menu/store/reducers/menu.reducer.ts
@@ -1,6 +1,6 @@
 import { createReducer, on, Action } from '@ngrx/store';
 import * as loadMenusActions from '../actions/menu.actions';
-import {DishView} from '../../../shared/view-models/interfaces';
+import { DishView } from '../../../shared/view-models/interfaces';
 
 export interface MenuState {
   loading: boolean;
@@ -18,9 +18,39 @@ export const initialState: MenuState = {
 
 const loadMenusReducer = createReducer(
   initialState,
-  on(loadMenusActions.loadMenus, state => ({...state, loading: true, loaded: false, dishes: [] })),
-  on(loadMenusActions.loadMenusSuccess, (state, {content}) => ({...state, loading: false, loaded: true, dishes: content})),
-  on(loadMenusActions.loadMenuFail, (state, {error}) => ({...state, errorMessage: error.message}))
+  on(loadMenusActions.loadMenus, (state) => ({
+    ...state,
+    loading: true,
+    loaded: false,
+    dishes: [],
+  })),
+  on(loadMenusActions.loadMenusSuccess, (state, { content }) => ({
+    ...state,
+    loading: false,
+    loaded: true,
+    dishes: content,
+  })),
+  on(loadMenusActions.loadMenusFail, (state, { error }) => ({
+    ...state,
+    errorMessage: error.message,
+  })),
+  on(loadMenusActions.updateDishExtras, (state, { dish }) => {
+    // TODO: Fix
+    const dishToUpdate: DishView = {
+      ...state.dishes.find((d) => d.dish.id === dish.dish.id),
+    };
+    dishToUpdate.extras = dish.extras;
+    const stateCopy = { ...state };
+    const dishes = [
+      ...stateCopy.dishes.map((d) =>
+        d.dish.id === dish.dish.id ? dishToUpdate : d,
+      ),
+    ];
+    return {
+      ...stateCopy,
+      dishes,
+    };
+  }),
 );
 
 export function reducer(state: MenuState | undefined, action: Action) {

--- a/angular/src/app/menu/store/selectors/menu.selectors.ts
+++ b/angular/src/app/menu/store/selectors/menu.selectors.ts
@@ -1,19 +1,19 @@
-import {createFeatureSelector, createSelector} from '@ngrx/store';
-import * as fromMenu from '../reducers/menu.reducer';
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import * as fromMenu from '../reducers';
 
-export const selectMenuState = createFeatureSelector<fromMenu.MenuState>('menu');
+export const selectMenuState = createFeatureSelector<fromMenu.AppState>('menu');
 
 export const getDishes = createSelector(
   selectMenuState,
-  state => state.dishes
+  (state) => state.menu.dishes,
 );
 
 export const getLoading = createSelector(
   selectMenuState,
-  state => state.loading
+  (state) => state.menu.loading,
 );
 
 export const getLoaded = createSelector(
   selectMenuState,
-  state => state.loaded
+  (state) => state.menu.loaded,
 );

--- a/angular/src/app/sidenav/container/sidenav/sidenav.component.ts
+++ b/angular/src/app/sidenav/container/sidenav/sidenav.component.ts
@@ -61,7 +61,7 @@ export class SidenavComponent implements OnInit {
                 extras: orderToUpdate.details.extras,
                 orderLine: {
                   ...orderToUpdate.details.orderLine,
-                  amount: ++orderToUpdate.details.orderLine.amount,
+                  amount: orderToUpdate.details.orderLine.amount + 1,
                 },
               },
             },
@@ -85,7 +85,7 @@ export class SidenavComponent implements OnInit {
                   extras: orderToUpdate.details.extras,
                   orderLine: {
                     ...orderToUpdate.details.orderLine,
-                    amount: --orderToUpdate.details.orderLine.amount,
+                    amount: orderToUpdate.details.orderLine.amount - 1,
                   },
                 },
               },

--- a/angular/src/app/sidenav/store/selectors/order.selectors.ts
+++ b/angular/src/app/sidenav/store/selectors/order.selectors.ts
@@ -1,6 +1,6 @@
-import { createFeatureSelector, createSelector } from '@ngrx/store';
-import * as fromOrders from '../reducers/order.reducer';
+import { createSelector } from '@ngrx/store';
 import * as fromFeature from '../reducers';
+import * as fromOrders from '../reducers/order.reducer';
 
 export const {
   selectIds,

--- a/angular/src/app/user-area/store/selectors/auth.selectors.ts
+++ b/angular/src/app/user-area/store/selectors/auth.selectors.ts
@@ -1,24 +1,24 @@
-import {createFeatureSelector, createSelector} from '@ngrx/store';
-import * as fromAuth from '../reducers/auth.reducer';
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import * as fromAuth from '../reducers';
 
-export const selectAuthState = createFeatureSelector<fromAuth.AuthState>('auth');
+export const selectAuthState = createFeatureSelector<fromAuth.AppState>('auth');
 
 export const getToken = createSelector(
   selectAuthState,
-  state => state.token.token
+  (state) => state.auth.token.token,
 );
 
 export const getRole = createSelector(
   selectAuthState,
-  state => state.user.role
+  (state) => state.auth.user.role,
 );
 
 export const getUserName = createSelector(
   selectAuthState,
-  state => state.user.user
+  (state) => state.auth.user.user,
 );
 
 export const getLogged = createSelector(
   selectAuthState,
-  state => state.user.logged
+  (state) => state.auth.user.logged,
 );


### PR DESCRIPTION
Some components and services mutated data from the store after fixing in PR #285, what is forbidden and therefore the browser gives some errors related.  

This PR fixes this adding more actions and reducers to change the state when selecting dishes and extras.
