### PR TITLE
#280: Upgrade to traefik v2 config

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -3,8 +3,12 @@ version: "3"
 services:
   reverse-proxy:
     restart: always
-    image: traefik
-    command: --api --docker
+    image: traefik:2.0.0
+    command:
+      - "--api.dashboard=true"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--entrypoints.web.address=:80"
     networks:
       - my-thai-star
     ports:
@@ -14,6 +18,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
     labels:
       - "traefik.enable=false"
+
   java:
     build: "java/"
     restart: always
@@ -21,10 +26,14 @@ services:
     networks:
       - my-thai-star
     labels:
-      - "traefik.frontend.rule=PathPrefixStrip:/api/;AddPrefix:/mythaistar"
-      - "traefik.backend.healthcheck.path=/mythaistar/services/rest/dishmanagement/v1/category/0/"
-      - "traefik.backend.healthcheck.interval=10s"
-      - "traefik.backend.healthcheck.scheme=http"
+      - "traefik.http.routers.java.rule=PathPrefix(`/api/`)"
+      - "traefik.http.routers.java.middlewares=fixpath"
+      - "traefik.http.middlewares.fixpath.chain.middlewares=remove-api,add-mythaistar"
+      - "traefik.http.middlewares.remove-api.stripprefix.prefixes=/api"
+      - "traefik.http.middlewares.add-mythaistar.addprefix.prefix=/mythaistar"
+      - "traefik.http.services.java.loadBalancer.healthcheck.path=/mythaistar/services/rest/dishmanagement/v1/category/0/"
+      - "traefik.http.services.java.loadBalancer.healthcheck.interval=10s"
+      - "traefik.http.services.java.loadBalancer.healthcheck.scheme=http"
   angular:
     build: "angular/"
     restart: always
@@ -32,10 +41,10 @@ services:
     networks:
       - my-thai-star
     labels:
-      - "traefik.frontend.rule=PathPrefix:/"
-      - "traefik.backend.healthcheck.path=/health"
-      - "traefik.backend.healthcheck.interval=10s"
-      - "traefik.backend.healthcheck.scheme=http"
+      - "traefik.http.routers.angular.rule=PathPrefix(`/`)"
+      - "traefik.http.services.angular.loadBalancer.healthcheck.path=/health"
+      - "traefik.http.services.angular.loadBalancer.healthcheck.interval=10s"
+      - "traefik.http.services.angular.loadBalancer.healthcheck.scheme=http"
 networks:
   my-thai-star:
     driver: bridge

--- a/documentation/traefik-reverse-proxy.asciidoc
+++ b/documentation/traefik-reverse-proxy.asciidoc
@@ -12,10 +12,10 @@ Example of labels:
 [source,yaml]
 ----
 labels:
-    - "traefik.frontend.rule=PathPrefixStrip:/api/;AddPrefix:/mythaistar"
-    - "traefik.backend.healthcheck.path=/mythaistar/services/rest/dishmanagement/v1/category/0/"
-    - "traefik.backend.healthcheck.interval=10s"
-    - "traefik.backend.healthcheck.scheme=http"
+    - "traefik.http.routers.angular.rule=PathPrefix(`/`)"
+    - "traefik.http.services.angular.loadBalancer.healthcheck.path=/health"
+    - "traefik.http.services.angular.loadBalancer.healthcheck.interval=10s"
+    - "traefik.http.services.angular.loadBalancer.healthcheck.scheme=http"
 ----
 
 === How to use it

--- a/reverse-proxy/traefik/README.asciidoc
+++ b/reverse-proxy/traefik/README.asciidoc
@@ -12,10 +12,10 @@ Example of labels:
 [source,yaml]
 ----
 labels:
-    - "traefik.frontend.rule=PathPrefixStrip:/api/;AddPrefix:/mythaistar"
-    - "traefik.backend.healthcheck.path=/mythaistar/services/rest/dishmanagement/v1/category/0/"
-    - "traefik.backend.healthcheck.interval=10s"
-    - "traefik.backend.healthcheck.scheme=http"
+    - "traefik.http.routers.angular.rule=PathPrefix(`/`)"
+    - "traefik.http.services.angular.loadBalancer.healthcheck.path=/health"
+    - "traefik.http.services.angular.loadBalancer.healthcheck.interval=10s"
+    - "traefik.http.services.angular.loadBalancer.healthcheck.scheme=http"
 ----
 
 === How to use it

--- a/reverse-proxy/traefik/docker-compose.yml
+++ b/reverse-proxy/traefik/docker-compose.yml
@@ -3,8 +3,12 @@ version: "3"
 services:
   reverse-proxy:
     restart: always
-    image: traefik
-    command: --api --docker
+    image: traefik:2.0.0
+    command:
+      - "--api.dashboard=true"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--entrypoints.web.address=:80"
     networks:
       - my-thai-star
     ports:
@@ -21,10 +25,14 @@ services:
     networks:
       - my-thai-star
     labels:
-      - "traefik.frontend.rule=PathPrefixStrip:/api/;AddPrefix:/mythaistar"
-      - "traefik.backend.healthcheck.path=/mythaistar/services/rest/dishmanagement/v1/category/0/"
-      - "traefik.backend.healthcheck.interval=10s"
-      - "traefik.backend.healthcheck.scheme=http"
+      - "traefik.http.routers.java.rule=PathPrefix(`/api/`)"
+      - "traefik.http.routers.java.middlewares=fixpath"
+      - "traefik.http.middlewares.fixpath.chain.middlewares=remove-api,add-mythaistar"
+      - "traefik.http.middlewares.remove-api.stripprefix.prefixes=/api"
+      - "traefik.http.middlewares.add-mythaistar.addprefix.prefix=/mythaistar"
+      - "traefik.http.services.java.loadBalancer.healthcheck.path=/mythaistar/services/rest/dishmanagement/v1/category/0/"
+      - "traefik.http.services.java.loadBalancer.healthcheck.interval=10s"
+      - "traefik.http.services.java.loadBalancer.healthcheck.scheme=http"
   angular:
     build: "../angular/"
     restart: always
@@ -32,10 +40,10 @@ services:
     networks:
       - my-thai-star
     labels:
-      - "traefik.frontend.rule=PathPrefix:/"
-      - "traefik.backend.healthcheck.path=/health"
-      - "traefik.backend.healthcheck.interval=10s"
-      - "traefik.backend.healthcheck.scheme=http"
+      - "traefik.http.routers.angular.rule=PathPrefix(`/`)"
+      - "traefik.http.services.angular.loadBalancer.healthcheck.path=/health"
+      - "traefik.http.services.angular.loadBalancer.healthcheck.interval=10s"
+      - "traefik.http.services.angular.loadBalancer.healthcheck.scheme=http"
 networks:
   my-thai-star:
     driver: bridge


### PR DESCRIPTION
[traefik](https://traefik.io) v2 has been published, using renewed concepts and new configuration. The docker-compose sample file for a traefik with reverse proxy role - as provided within MTS - has already started to use the v2 version, producing failures due to v1 configuration.

This PR updates the configuration to v2 format, implementing the necessary changes as e.g. documented within the [Traefik v1 to v2 Migration Guide](https://docs.traefik.io/migration/v1-to-v2/).
