### PR TITLE
Fix for #297: remove intl dependency from polyfills

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -71,7 +71,6 @@
     "flag-icon-css": "^3.3.0",
     "hammerjs": "^2.0.8",
     "highlight.js": "^9.15.6",
-    "intl": "^1.2.5",
     "leaflet": "^1.5.1",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",

--- a/angular/src/polyfills.ts
+++ b/angular/src/polyfills.ts
@@ -57,12 +57,6 @@ import 'zone.js/dist/zone'; // Included with Angular-CLI.
  * APPLICATION IMPORTS
  */
 
-/**
- * Date, currency, decimal and percent pipes.
- * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10
- */
-import 'intl'; // Run `npm install --save intl`.
-
 if (typeof SVGElement.prototype.contains === 'undefined') {
   SVGElement.prototype.contains = HTMLDivElement.prototype.contains;
 }

--- a/angular/src/test.ts
+++ b/angular/src/test.ts
@@ -12,7 +12,6 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
-import 'intl/locale-data/jsonp/en.js';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare var __karma__: any;

--- a/angular/yarn.lock
+++ b/angular/yarn.lock
@@ -4525,11 +4525,6 @@ internal-ip@^4.3.0:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
 
-intl@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
-  integrity sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94=
-
 invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"


### PR DESCRIPTION
reverses change from #172. Tests runs successful. The upgrade to Angular 8 may have made use of intl meanwhile unnecessary.